### PR TITLE
All tests passing. Fixes #1, Preprocessor Deadlock

### DIFF
--- a/CParser/Helpers/AsyncStreamBlock.cs
+++ b/CParser/Helpers/AsyncStreamBlock.cs
@@ -23,22 +23,13 @@ namespace CParser.Helpers
             CancellationToken = cancellation;
             Sentinel = sentinel;
 
-            Task.Run(DoWork);
-                
-            Completion = SourceBlock.Completion;
+            Completion = SourceBlock
+                .PostAllAsync(
+                    Function(TargetBlock.ToStream(Sentinel)),
+                    CancellationToken).ContinueWith(_ => SourceBlock.Complete());
         }
 
         public Task Completion { get; }
-
-        protected async Task DoWork()
-        {
-            await SourceBlock
-                .PostAllAsync(
-                    Function(TargetBlock.ToStream(Sentinel)), 
-                    CancellationToken);
-
-            SourceBlock.Complete();
-        }
 
         public void Complete()
         {

--- a/CParser/Helpers/Functions.cs
+++ b/CParser/Helpers/Functions.cs
@@ -5,15 +5,24 @@ namespace CParser.Helpers
 {
     public static class Functions
     {
-        public static IPropagatorBlock<T, T> Compose<T>(params AsyncStreamFunc<T, T>[] functions)
+        public static IPropagatorBlock<T, T> ComposeBuffer<T>(params AsyncStreamFunc<T, T>[] functions)
         {
-            return Compose(default!, functions);
+            return ComposeBuffer(default!, functions);
         }
-        public static IPropagatorBlock<T, T> Compose<T>(T sentinel, params AsyncStreamFunc<T, T>[] functions)
+        public static IPropagatorBlock<T, T> ComposeBuffer<T>(T sentinel, params AsyncStreamFunc<T, T>[] functions)
         {
             return functions.Aggregate(
                     (IPropagatorBlock<T, T>)new BufferBlock<T>(), 
-                    (block, func) => block.StreamAndChain(func, null, sentinel));
+                    (block, func) => block.BufferAndChain(func, null, sentinel));
+        }
+        public static AsyncStreamFunc<T, T> Compose<T>(params AsyncStreamFunc<T, T>[] functions)
+        {
+            return Compose(default!, functions);
+        }
+        public static AsyncStreamFunc<T, T> Compose<T>(T sentinel, params AsyncStreamFunc<T, T>[] functions)
+        {
+            return functions.Aggregate(
+                    (func1, func2) => input => func2(new AsyncStreamWrapper<T>(func1(input), sentinel)));
         }
     }
 }

--- a/CParser/Lexing/Lexer.cs
+++ b/CParser/Lexing/Lexer.cs
@@ -83,7 +83,7 @@ namespace CParser.Lexing
 
         public static IPropagatorBlock<char, Token> AsBlock(TranslationUnit translationUnit, bool preprocessorTokens, bool outputTrivia)
         {
-            return Streaming(translationUnit, preprocessorTokens, outputTrivia).AsBlock();
+            return Streaming(translationUnit, preprocessorTokens, outputTrivia).Buffered();
         }
 
         protected async IAsyncEnumerable<Token> Lex()
@@ -99,7 +99,7 @@ namespace CParser.Lexing
                     var sb = new StringBuilder();
                     while (!await InputStream.Eof() && ((c = await InputStream.Peek()) != '>'))
                     {
-                        sb.Append(c);
+                        sb.Append(await InputStream.Read());
                     }
                     TranslationUnit.LexerState = LexerState.LexerReady;
                     yield return new ValueToken<string>(Terminal.Filename, line, column, filename, sb.ToString());

--- a/tests/ParserTests.cs
+++ b/tests/ParserTests.cs
@@ -20,7 +20,7 @@ namespace tests
         [Fact]
         public async void TestBasicC89Program()
         {
-            var program = @"#include ""stdio.h""
+            var program = @"#include <stdio.h>
                             main() {
                                 printf(""Hello, world!\n"");
                             }";


### PR DESCRIPTION
#include<...> with angle brackets now works as a lexer hack.

All async functions are truly cooperative async now (with the
exception of the initial character buffer). There are no more
`Task.Run()` calls. To do this, added extensions for chaining
`AsyncStreamFunc<T>`s together, and migrated the preprocessor
pipeline to chained functions instead of `BufferBlock`s.